### PR TITLE
Added banknifty options to dvc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ sample.py
 /temporary
 
 /.idea
+*.tar.bz2

--- a/app/data/historical_data/README.md
+++ b/app/data/historical_data/README.md
@@ -1,0 +1,3 @@
+### Banknifty
+- `banknifty` has `1` minute options data from 2017-01-01 to 2024-04-01.
+- It is collected from [Algo Test](https://algotest.in/simulator) website.

--- a/app/data/historical_data/options/.dvc/.gitignore
+++ b/app/data/historical_data/options/.dvc/.gitignore
@@ -1,0 +1,3 @@
+/config.local
+/tmp
+/cache

--- a/app/data/historical_data/options/.dvc/config
+++ b/app/data/historical_data/options/.dvc/config
@@ -1,0 +1,6 @@
+[core]
+    remote = gdrive
+['remote "gdrive"']
+    url = gdrive://1nCZsTY5QkeUVOjbIKou6DEWsk5rBR9BP  
+    gdrive_acknowledge_abuse = true
+

--- a/app/data/historical_data/options/.dvcignore
+++ b/app/data/historical_data/options/.dvcignore
@@ -1,0 +1,3 @@
+# Add patterns of files dvc should ignore, which could improve
+# the performance. Learn more at
+# https://dvc.org/doc/user-guide/dvcignore

--- a/app/data/historical_data/options/banknifty.tar.bz2.dvc
+++ b/app/data/historical_data/options/banknifty.tar.bz2.dvc
@@ -1,0 +1,4 @@
+outs:
+- md5: 61632e8d7ae0db0eba69bb2368ef446d
+  size: 3916494686
+  path: banknifty.tar.bz2


### PR DESCRIPTION
- Downloaded banknifty options data from algo test. 
- Adding raw data to dvc. 
- Using gdrive as dvc remote storage.
- Dataset was pushed to dvc and adding the hash files to github