### PR TITLE
Refactor streaming module and rename classes

### DIFF
--- a/app/data_layer/streaming/__init__.py
+++ b/app/data_layer/streaming/__init__.py
@@ -1,2 +1,2 @@
-from .streaming import Streaming  # isort:skip
-from .kafka_streaming import KafkaStreaming
+from .streamer import Streamer  # isort:skip
+from .streamers import *

--- a/app/data_layer/streaming/streamer.py
+++ b/app/data_layer/streaming/streamer.py
@@ -9,7 +9,7 @@ from omegaconf import DictConfig
 from registrable import Registrable
 
 
-class Streaming(ABC, Registrable):
+class Streamer(ABC, Registrable):
     """
     This is the base class for all streaming classes. All the concrete streaming classes
     should inherit from this class and implement the __call__ method. This class also
@@ -30,7 +30,7 @@ class Streaming(ABC, Registrable):
         raise NotImplementedError
 
     @classmethod
-    def from_cfg(cls, cfg: DictConfig) -> Optional["Streaming"]:
+    def from_cfg(cls, cfg: DictConfig) -> Optional["Streamer"]:
         """
         This class method creates a streaming object from the configuration file.
 

--- a/app/data_layer/streaming/streamers/__init__.py
+++ b/app/data_layer/streaming/streamers/__init__.py
@@ -1,0 +1,1 @@
+from .kafka_streamer import KafkaStreamer

--- a/app/data_layer/streaming/streamers/kafka_streamer.py
+++ b/app/data_layer/streaming/streamers/kafka_streamer.py
@@ -4,14 +4,14 @@ from typing import Optional
 from kafka import KafkaProducer
 from omegaconf import DictConfig
 
-from app.data_layer.streaming import Streaming
+from app.data_layer.streaming import Streamer
 from app.utils.common.logger import get_logger
 
 logger = get_logger(Path(__file__).name)
 
 
-@Streaming.register("kafka")
-class KafkaStreaming(Streaming):
+@Streamer.register("kafka")
+class KafkaStreamer(Streamer):
     """
     Kafka streaming class to send data to Kafka server. This can be used as a callback
     function to send data to Kafka.
@@ -56,7 +56,7 @@ class KafkaStreaming(Streaming):
                 logger.error("Error closing Kafka producer: %s", e)
 
     @classmethod
-    def from_cfg(cls, cfg: DictConfig) -> Optional["KafkaStreaming"]:
+    def from_cfg(cls, cfg: DictConfig) -> Optional["KafkaStreamer"]:
         try:
             return cls(cfg["kafka_server"], cfg["kafka_topic"])
         except Exception as e:

--- a/app/sockets/connections/smartsocket_connection.py
+++ b/app/sockets/connections/smartsocket_connection.py
@@ -7,7 +7,7 @@ from omegaconf import DictConfig
 from app.data_layer.database.sqlite.crud.smartapi_crud import (
     get_smartapi_tokens_by_all_conditions,
 )
-from app.data_layer.streaming import Streaming
+from app.data_layer.streaming import Streamer
 from app.sockets.connections.websocket_connection import WebsocketConnection
 from app.sockets.twisted_sockets import SmartSocket
 from app.utils.common import init_from_cfg
@@ -169,7 +169,7 @@ class SmartSocketConnection(WebsocketConnection):
         )
 
         # Initialize the callback to save the received data from the socket.
-        save_data_callback = init_from_cfg(cfg.streaming, Streaming)
+        save_data_callback = init_from_cfg(cfg.streaming, Streamer)
 
         smart_socket = SmartSocket.initialize_socket(cfg.provider, save_data_callback)
         connection = cls(smart_socket)

--- a/tests/sockets/connections/test_smartsocket_connection.py
+++ b/tests/sockets/connections/test_smartsocket_connection.py
@@ -47,15 +47,15 @@ def mock_validate_symbol_and_get_token(mocker: MockerFixture) -> MockType:
 
 
 @pytest.fixture
-def mock_streaming(mocker: MockerFixture) -> MockType:
-    return mocker.patch("app.sockets.connections.smartsocket_connection.Streaming")
+def mock_streamer(mocker: MockerFixture) -> MockType:
+    return mocker.patch("app.sockets.connections.smartsocket_connection.Streamer")
 
 
 @pytest.fixture
-def mock_init_from_cfg(mocker: MockerFixture, mock_streaming) -> MockType:
+def mock_init_from_cfg(mocker: MockerFixture, mock_streamer) -> MockType:
     return mocker.patch(
         "app.sockets.connections.smartsocket_connection.init_from_cfg",
-        return_value=mock_streaming,
+        return_value=mock_streamer,
     )
 
 
@@ -151,7 +151,7 @@ def test_init_from_cfg_valid_cfg(
     connection_cfg: dict,
     mock_smartsocket: MockType,
     mock_init_from_cfg: MockType,
-    mock_streaming: MockType,
+    mock_streamer: MockType,
     smartapi_tokens: tuple[list[SmartAPIToken], dict[str, str]],
     mock_get_smartapi_tokens_by_all_conditions: MockType,
 ):
@@ -166,8 +166,8 @@ def test_init_from_cfg_valid_cfg(
     assert connection is not None
     assert connection.websocket == mock_smartsocket
 
-    mock_init_from_cfg.assert_called_with(cfg.streaming, mock_streaming)
-    assert mock_init_from_cfg.return_value == mock_streaming
+    mock_init_from_cfg.assert_called_with(cfg.streaming, mock_streamer)
+    assert mock_init_from_cfg.return_value == mock_streamer
 
     mock_smartsocket.set_tokens.assert_called_once()
     mock_smartsocket.initialize_socket.assert_called_once()


### PR DESCRIPTION
- Renamed `Streaming` class to `Streamer` in `streamer.py`
- Moved `KafkaStreamer` to `streamers` package
- Added `__init__.py` to `streamers` package
- Updated references to `Streaming` to use `Streamer` in other modules