### PR TITLE
Remove User Verification With Mobile Scope

### DIFF
--- a/backend/app/data_layer/database/crud/user_crud.py
+++ b/backend/app/data_layer/database/crud/user_crud.py
@@ -89,7 +89,10 @@ def get_user_by_attr(attr_name: str, attr_value: str, session: Session) -> User:
     result = session.exec(statement).first()
 
     if not result:
-        raise HTTPException(status.HTTP_404_NOT_FOUND, "User not found")
+        raise HTTPException(
+            status.HTTP_404_NOT_FOUND,
+            f"User not found with given {attr_name} {attr_value}",
+        )
 
     return result
 
@@ -204,14 +207,14 @@ def delete_user(user_id: int, session: Session) -> None:
 
 #### UserVerification CRUD operations ####
 @with_session
-def get_user_verification(recipient: str, session: Session) -> UserVerification | None:
+def get_user_verification(email: str, session: Session) -> UserVerification | None:
     """
-    Retrieve a user verification object from the database using the recipient (email/phone number).
+    Retrieve a user verification object from the database using the email.
 
     Parameters:
     ----------
-    recipient: ``str``
-        The email or phone number of the user to retrieve the verification object
+    email: ``str``
+        The email of the user to retrieve the verification object
     session: ``Session``
         Session object to interact with the database
 
@@ -220,7 +223,7 @@ def get_user_verification(recipient: str, session: Session) -> UserVerification 
     ``UserVerification | None``
         The user verification object if found, otherwise None
     """
-    statement = select(UserVerification).where(UserVerification.recipient == recipient)
+    statement = select(UserVerification).where(UserVerification.email == email)
     result = session.exec(statement).first()
 
     return result
@@ -245,7 +248,7 @@ def create_or_update_user_verification(
     """
 
     existing_user_verification = get_user_verification(
-        user_verification.recipient, session=session
+        user_verification.email, session=session
     )
 
     if not existing_user_verification:
@@ -257,9 +260,6 @@ def create_or_update_user_verification(
         existing_user_verification.expiration_time = user_verification.expiration_time
         existing_user_verification.reverified_datetime = (
             user_verification.reverified_datetime or datetime.datetime.now()
-        )
-        existing_user_verification.verification_medium = (
-            user_verification.verification_medium
         )
 
     session.add(existing_user_verification)

--- a/backend/app/data_layer/database/models/user_model.py
+++ b/backend/app/data_layer/database/models/user_model.py
@@ -97,10 +97,8 @@ class UserVerification(SQLModel, table=True):  # type: ignore
 
     Attributes:
     ----------
-    recipient: ``str``
-        The email or phone number of the user
-    verification_medium: ``str``
-        The medium used for verification (email/phone)
+    email: ``str``
+        The email address of the user
     verification_code: ``str``
         The verification code sent to the user
     expiration_time: ``int``
@@ -112,8 +110,7 @@ class UserVerification(SQLModel, table=True):  # type: ignore
         password reset process
     """
 
-    recipient: str = Field(primary_key=True)
-    verification_medium: str
+    email: str = Field(primary_key=True)
     verification_code: str = Field(max_length=6, min_length=6)
     expiration_time: int
     verification_datetime: datetime | None = Field(

--- a/backend/app/routers/authentication/authentication.py
+++ b/backend/app/routers/authentication/authentication.py
@@ -146,7 +146,7 @@ async def verify_user(request: EmailVerificationRequest) -> dict:
     if user_verification is None:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
-            detail="User does not exist with this email or phone",
+            detail="User does not exist with this email",
         )
 
     # Check if verification code matches

--- a/backend/app/routers/authentication/authentication.py
+++ b/backend/app/routers/authentication/authentication.py
@@ -1,6 +1,7 @@
 # pylint: disable=no-value-for-parameter
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
+from typing import cast
 
 import hydra
 from fastapi import APIRouter, Depends, HTTPException, status
@@ -12,10 +13,12 @@ from app.data_layer.database.crud.user_crud import (
     get_user_verification,
 )
 from app.data_layer.database.models.user_model import User, UserVerification
+from app.notification.email.email_provider import EmailProvider
 from app.notification.provider import NotificationProvider
-from app.schemas.user_model import UserSignIn, UserSignup, UserVerificationRequest
+from app.schemas.user_model import EmailVerificationRequest, UserSignIn, UserSignup
 from app.utils.common import init_from_cfg
 from app.utils.common.logger import get_logger
+from app.utils.constants import EMAIL
 
 from .authenticate import (
     generate_verification_code,
@@ -32,10 +35,12 @@ logger = get_logger(Path(__file__).name)
 with hydra.initialize_config_dir(config_dir=f"{ROOT_DIR}/configs", version_base=None):
     notification_provider_cfg = hydra.compose(config_name="user_verification")
 
-notification_provider = init_from_cfg(
-    notification_provider_cfg.user_verifier, base_class=NotificationProvider
+email_notification_provider: EmailProvider = cast(
+    EmailProvider,
+    init_from_cfg(
+        notification_provider_cfg.user_verifier, base_class=NotificationProvider
+    ),
 )
-
 router = APIRouter(prefix="/authentication", tags=["authentication"])
 
 
@@ -68,43 +73,31 @@ async def signin(user: UserSignIn) -> dict:
 
 
 @router.post("/send-verification-code", status_code=status.HTTP_200_OK)
-async def send_verification_code(email_or_phone: str, verification_medium: str) -> dict:
+async def send_verification_code(email: str) -> dict:
     """
-    Send a verification code to the user's email or phone number.
+    Send a verification code to the user's email.
 
     Parameters:
     -----------
-    - **email_or_phone** (str): The email or phone number to send the verification code to.
-    - **verification_medium** (str): The medium for sending the code ('email' or 'phone').
+    - **email** (str): The email to send the verification code to.
 
     Returns:
     --------
     - JSON response indicating whether the code was sent successfully.
     """
+
     logger.info(
-        "Sending verification code to %s using %s", email_or_phone, verification_medium
+        "Sending verification code to %s using %s", email, email_notification_provider
     )
 
-    # Validate verification medium
-    if verification_medium not in {"email", "phone"}:
-        raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST,
-            detail="Invalid verification medium. Use 'email' or 'phone'.",
-        )
-
     # Fetch the user by email address
-    user = get_user_by_attr(verification_medium, email_or_phone)
-    if not user:
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND,
-            detail="User does not exist with this email or phone.",
-        )
+    user = get_user_by_attr(EMAIL, email)
 
     # Check if the user is already verified
     if user.is_verified:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
-            detail="Email or phone is already verified.",
+            detail="Email is already verified.",
         )
 
     # Generate and save the verification code
@@ -115,45 +108,40 @@ async def send_verification_code(email_or_phone: str, verification_medium: str) 
 
     create_or_update_user_verification(
         UserVerification(
-            recipient=email_or_phone,
-            verification_medium=verification_medium,
+            email=email,
             verification_code=verification_code,
             expiration_time=expiration_time,
         )
     )
 
     # Send the notification
-    notification_provider.send_notification(
+    email_notification_provider.send_notification(
         code=verification_code,
-        recipient_email=email_or_phone,
+        recipient_email=email,
         recipient_name=user.username,
     )
 
-    return {
-        "message": f"Verification code sent to {email_or_phone}. Valid for 10 minutes."
-    }
+    return {"message": f"Verification code sent to {email}. Valid for 10 minutes."}
 
 
 @router.post("/verify-code", status_code=status.HTTP_200_OK)
-async def verify_user(request: UserVerificationRequest) -> dict:
+async def verify_user(request: EmailVerificationRequest) -> dict:
     """
-    Verify the email or phone of the user using the provided verification code.
+    Verify the email of the user using the provided verification code.
 
     Parameters:
     -----------
     - **request**: UserVerificationRequest
-        The request object containing the email or phone and the verification code.
-    - **response**: Response
-        The FastAPI Response object for setting custom headers or cookies.
+        The request object containing the email and the verification code.
 
     Returns:
     --------
     - JSON response indicating success or failure of the verification.
     """
-    logger.info("Verification attempt for %s", request.email_or_phone)
+    logger.info("Verification attempt for %s", request.email)
 
     # Fetch user verification details
-    user_verification = get_user_verification(request.email_or_phone)
+    user_verification = get_user_verification(request.email)
 
     if user_verification is None:
         raise HTTPException(
@@ -175,9 +163,9 @@ async def verify_user(request: UserVerificationRequest) -> dict:
         )
 
     # Update verification status
-    update_user_verification_status(request.email_or_phone)
+    update_user_verification_status(request.email)
 
-    return {"message": "Email or phone verified successfully"}
+    return {"message": "Email verified successfully"}
 
 
 @router.get(

--- a/backend/app/schemas/user_model.py
+++ b/backend/app/schemas/user_model.py
@@ -24,10 +24,10 @@ class UserSignIn(BaseModel):
     password: str
 
 
-class UserVerificationRequest(BaseModel):
+class EmailVerificationRequest(BaseModel):
     """
     UserVerification schema for user verification
     """
 
     verification_code: str
-    email_or_phone: str
+    email: str

--- a/backend/app/utils/constants.py
+++ b/backend/app/utils/constants.py
@@ -1,5 +1,9 @@
 from app.utils.fetch_data import get_required_env_var
 
+# Authentication Constants
+EMAIL = "email"
+
+
 # Secret keys for JWT tokens
 JWT_SECRET = get_required_env_var("JWT_SECRET_KEY")
 JWT_REFRESH_SECRET = get_required_env_var("JWT_REFRESH_SECRET_KEY")

--- a/backend/tests/data_layer/database/crud/conftest.py
+++ b/backend/tests/data_layer/database/crud/conftest.py
@@ -1,40 +1,7 @@
-from typing import Generator
-
 import pytest
-from sqlalchemy.engine import Engine
-from sqlmodel import Session, create_engine
 
-from app.data_layer.database.db_connections.sqlite import (
-    create_db_and_tables,
-    get_session,
-)
 from app.data_layer.database.models import Instrument, InstrumentPrice
 from app.utils.common.types.financial_types import DataProviderType, ExchangeType
-
-
-@pytest.fixture(scope="function")
-def engine() -> Generator[Engine, None, None]:
-    """
-    Using sqlite in-memory database instead of PostgreSQL for testing.
-    Because it is faster and does not require a separate database server.
-    Also, the operations are similar to PostgreSQL.
-    """
-    engine = create_engine("sqlite:///:memory:")
-    create_db_and_tables(engine)
-
-    yield engine
-
-    engine.dispose()
-
-
-@pytest.fixture(scope="function")
-def session(engine) -> Generator[Session, None, None]:
-    """
-    Fixture to provide a new database session for each test function.
-    Ensures each test runs in isolation with a clean database state.
-    """
-    with get_session(engine) as session:
-        yield session
 
 
 @pytest.fixture

--- a/backend/tests/routers/authentication/test_authenticate.py
+++ b/backend/tests/routers/authentication/test_authenticate.py
@@ -244,7 +244,7 @@ def test_signin_user(mock_session: MockType, test_user: User, sign_up_data: User
     with pytest.raises(HTTPException) as http_exe:
         signin_user(sign_up_data.email, sign_up_data.password)
     assert http_exe.value.status_code == status.HTTP_404_NOT_FOUND
-    assert http_exe.value.detail == "User not found"
+    assert http_exe.value.detail == "User not found with given email test@gmail.com"
 
     # Test: 10.2 ( Incorrect password )
     mock_session.first.return_value = test_user
@@ -281,7 +281,7 @@ def test_update_user_verification_status(mock_session: MockType, test_user: User
         update_user_verification_status(test_user.email)
 
     assert http_exe.value.status_code == status.HTTP_404_NOT_FOUND
-    assert http_exe.value.detail == "User not found"
+    assert http_exe.value.detail == "User not found with given email test@gmail.com"
     assert test_user.is_verified is False
 
     # Test: 11.2 ( Verify user )

--- a/backend/tests/routers/authentication/test_authentication.py
+++ b/backend/tests/routers/authentication/test_authentication.py
@@ -91,7 +91,7 @@ def mock_notification_provider(mocker: MockFixture):
     Mock the notification provider
     """
     return mocker.patch(
-        "app.routers.authentication.authentication.notification_provider",
+        "app.routers.authentication.authentication.email_notification_provider",
         MockNotificationProvider(),
     )
 
@@ -237,8 +237,7 @@ def test_send_verification_code(
     mock_generate_verification_code.return_value = "123456"
 
     response = client.post(
-        "/authentication/send-verification-code",
-        params={"email_or_phone": test_user.email, "verification_medium": "email"},
+        "/authentication/send-verification-code", params={"email": test_user.email}
     )
     assert response.status_code == 200
     assert response.json() == {
@@ -251,38 +250,28 @@ def test_send_verification_code(
     assert mock_notification_provider.recipient_email == test_user.email
     assert mock_notification_provider.recipient_name == test_user.username
 
-    # Test: 3.2 ( Invalid verification medium )
-    with pytest.raises(HTTPException) as exc:
-        client.post(
-            "/authentication/send-verification-code",
-            params={
-                "email_or_phone": test_user.email,
-                "verification_medium": "invalid",
-            },
-        )
-    assert exc.value.status_code == status.HTTP_400_BAD_REQUEST
-    assert exc.value.detail == "Invalid verification medium. Use 'email' or 'phone'."
-    mock_get_user_by_attr.return_value = None
-
-    # Test: 3.3 ( User does not exist )
-    with pytest.raises(HTTPException) as exc:
-        client.post(
-            "/authentication/send-verification-code",
-            params={"email_or_phone": test_user.email, "verification_medium": "email"},
-        )
-    assert exc.value.status_code == status.HTTP_404_NOT_FOUND
-    assert exc.value.detail == "User does not exist with this email or phone."
-
-    # Test: 3.4 ( Email or phone is already verified )
+    # Test: 3.2 ( Email is already verified )
     test_user.is_verified = True
     mock_get_user_by_attr.return_value = test_user
     with pytest.raises(HTTPException) as exc:
         client.post(
             "/authentication/send-verification-code",
-            params={"email_or_phone": test_user.email, "verification_medium": "email"},
+            params={"email": test_user.email},
         )
     assert exc.value.status_code == status.HTTP_400_BAD_REQUEST
-    assert exc.value.detail == "Email or phone is already verified."
+    assert exc.value.detail == "Email is already verified."
+
+    # # Test: 3.3 ( User does not exist )
+    mock_get_user_by_attr.side_effect = HTTPException(
+        status.HTTP_404_NOT_FOUND, f"User not found with given email {test_user.email}"
+    )
+    with pytest.raises(HTTPException) as exc:
+        client.post(
+            "/authentication/send-verification-code", params={"email": test_user.email}
+        )
+    assert exc.value.status_code == status.HTTP_404_NOT_FOUND
+    assert exc.value.detail == f"User not found with given email {test_user.email}"
+    mock_get_user_by_attr.reset_mock()
 
 
 # Test: 4
@@ -310,11 +299,11 @@ def test_verify_code(
         "/authentication/verify-code",
         json={
             "verification_code": test_verification_code,
-            "email_or_phone": test_user.email,
+            "email": test_user.email,
         },
     )
     assert response.status_code == 200
-    assert response.json()["message"] == "Email or phone verified successfully"
+    assert response.json()["message"] == "Email verified successfully"
     mock_update_user_verification_status.assert_called_once_with(test_user.email)
 
     # Test: 4.2 ( User does not exist )
@@ -324,7 +313,7 @@ def test_verify_code(
             "/authentication/verify-code",
             json={
                 "verification_code": test_verification_code,
-                "email_or_phone": test_user.email,
+                "email": test_user.email,
             },
         )
     assert exc.value.status_code == status.HTTP_404_NOT_FOUND
@@ -337,7 +326,7 @@ def test_verify_code(
             "/authentication/verify-code",
             json={
                 "verification_code": "654321",
-                "email_or_phone": test_user.email,
+                "email": test_user.email,
             },
         )
     assert exc.value.status_code == status.HTTP_400_BAD_REQUEST
@@ -351,7 +340,7 @@ def test_verify_code(
             "/authentication/verify-code",
             json={
                 "verification_code": test_verification_code,
-                "email_or_phone": test_user.email,
+                "email": test_user.email,
             },
         )
     assert exc.value.status_code == status.HTTP_400_BAD_REQUEST

--- a/backend/tests/routers/authentication/test_authentication.py
+++ b/backend/tests/routers/authentication/test_authentication.py
@@ -317,7 +317,7 @@ def test_verify_code(
             },
         )
     assert exc.value.status_code == status.HTTP_404_NOT_FOUND
-    assert exc.value.detail == "User does not exist with this email or phone"
+    assert exc.value.detail == "User does not exist with this email"
 
     # Test: 4.3 ( Invalid verification code )
     mock_get_user_verification.return_value = user_verification


### PR DESCRIPTION
## Description
Currently we have two options to verify the user with otp i.e email and phone. The phone verification is not yet implemented but had a scope of implementation in the future. But it is not require as email verification is itself sufficent. Also we had a single endpoint to verify both mobile and email which lead to errors and bugs. So Mobile verification option is removed in this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Simplified user verification process to focus exclusively on email.
  - Removed phone number verification support.

- **Bug Fixes**
  - Enhanced error messages to provide more context when a user is not found.
  - Improved clarity of error reporting in tests related to user authentication.

- **Refactor**
  - Updated database models and schemas to use email as the primary identifier.
  - Streamlined authentication and verification routes.
  - Removed verification medium complexity.

- **Chores**
  - Updated test fixtures and configurations to support the new email-only verification approach.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->